### PR TITLE
vimの表記をVimに修正

### DIFF
--- a/ProgrammerProfile/views.py
+++ b/ProgrammerProfile/views.py
@@ -100,7 +100,7 @@ SKILL_PLATFORM_CATEGORY = ('Windows',
                            '組み込み')
 
 SKILL_EDITOR_CATEGORY = ('vi',
-                         'vim',
+                         'Vim',
                          'Emacs',
                          'xyzzy',
                          'Sublime Text',


### PR DESCRIPTION
vimの表記をVimに修正しました
コマンド名は `vim` ですが、ソフトウェアとしてはVimという名前が使われています